### PR TITLE
WIP: Add native mobile support for button padding

### DIFF
--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -35,6 +35,10 @@ function gutenberg_register_spacing_support( $block_type ) {
  * @return array Block spacing CSS classes and inline styles.
  */
 function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
+	if ( gutenberg_skip_spacing_serialization ( $block_type ) ) {
+		return array();
+	}
+
 	$has_padding_support = gutenberg_has_spacing_feature_support( $block_type, 'padding' );
 	$has_margin_support  = gutenberg_has_spacing_feature_support( $block_type, 'margin' );
 	$styles              = array();
@@ -73,6 +77,21 @@ function gutenberg_has_spacing_feature_support( $block_type, $feature, $default 
 	// Check if the specific feature has been opted into individually
 	// via nested flag under `spacing`.
 	return gutenberg_block_has_support( $block_type, array( 'spacing', $feature ), $default );
+}
+
+/**
+ * Checks whether serialization of the current block's padding should occur.
+ *
+ * @param WP_Block_Type $block_type       Block Type.
+ *
+ * @return boolean
+ */
+function gutenberg_skip_spacing_serialization( $block_type ) {
+	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
+
+	return is_array( $spacing_support ) &&
+		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
+		$spacing_support[ '__experimentalSkipSerialization' ];
 }
 
 // Register the block support.

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -15,3 +15,4 @@ import './layout';
 export { useCustomSides } from './spacing';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
+export { useSpacingProps } from './use-spacing-props';

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -15,4 +15,4 @@ import './layout';
 export { useCustomSides } from './spacing';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
-export { useSpacingProps } from './use-spacing-props';
+export { getSpacingClassesAndStyles } from './use-spacing-props';

--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -11,3 +11,4 @@ import './font-size';
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
+export { getSpacingClassesAndStyles } from './use-spacing-props';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -140,6 +140,9 @@ const skipSerializationPaths = {
 	[ `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
 		COLOR_SUPPORT_KEY,
 	],
+	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+		SPACING_SUPPORT_KEY,
+	],
 	[ `__experimentalSkipFontSizeSerialization` ]: [ 'typography', 'fontSize' ],
 	[ `__experimentalSkipTypographySerialization` ]: without(
 		TYPOGRAPHY_SUPPORT_KEYS,

--- a/packages/block-editor/src/hooks/use-spacing-props.js
+++ b/packages/block-editor/src/hooks/use-spacing-props.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { getInlineStyles } from './style';
+
+// This utility is intended to assist where the serialization of the spacing
+// block support is being skipped for a block but the spacing related CSS
+// styles still need to be generated so they can be applied to inner elements.
+
+/**
+ * Determines the spacing related props for a block derived from its spacing block
+ * support attributes.
+ *
+ * @param  {Object} attributes Block attributes.
+ * @return {Object}            ClassName & style props from spacing block support.
+ */
+export function useSpacingProps( attributes ) {
+	const { style } = attributes;
+
+	// Collect inline styles for spacing.
+	const spacingStyles = style?.spacing || {};
+	const styleProp = getInlineStyles( { spacing: spacingStyles } );
+
+	return {
+		style: styleProp,
+	};
+}

--- a/packages/block-editor/src/hooks/use-spacing-props.js
+++ b/packages/block-editor/src/hooks/use-spacing-props.js
@@ -8,13 +8,14 @@ import { getInlineStyles } from './style';
 // styles still need to be generated so they can be applied to inner elements.
 
 /**
- * Determines the spacing related props for a block derived from its spacing block
- * support attributes.
+ * Provides the CSS class names and inline styles for a block's spacing support
+ * attributes.
  *
  * @param  {Object} attributes Block attributes.
- * @return {Object}            ClassName & style props from spacing block support.
+ *
+ * @return {Object} Spacing block support derived CSS classes & styles.
  */
-export function useSpacingProps( attributes ) {
+export function getSpacingClassesAndStyles( attributes ) {
 	const { style } = attributes;
 
 	// Collect inline styles for spacing.

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -13,7 +13,7 @@ export {
 	getColorClassesAndStyles as __experimentalGetColorClassesAndStyles,
 	useColorProps as __experimentalUseColorProps,
 	useCustomSides as __experimentalUseCustomSides,
-	useSpacingProps as __experimentalUseSpacingProps,
+	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
 } from './hooks';
 export * from './components';
 export * from './utils';

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -13,6 +13,7 @@ export {
 	getColorClassesAndStyles as __experimentalGetColorClassesAndStyles,
 	useColorProps as __experimentalUseColorProps,
 	useCustomSides as __experimentalUseCustomSides,
+	useSpacingProps as __experimentalUseSpacingProps,
 } from './hooks';
 export * from './components';
 export * from './utils';

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -63,6 +63,10 @@
 		},
 		"fontSize": true,
 		"reusable": false,
+		"spacing": {
+			"__experimentalSkipSerialization": true,
+			"padding": true
+		},
 		"__experimentalBorder": {
 			"radius": true,
 			"__experimentalSkipSerialization": true

--- a/packages/block-library/src/button/controls.native.js
+++ b/packages/block-library/src/button/controls.native.js
@@ -1,0 +1,107 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	ToolbarGroup,
+	ToolbarButton,
+	BottomSheetSelectControl,
+} from '@wordpress/components';
+import { link } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import ColorEdit from './color-edit';
+
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
+
+function WidthPanel( { selectedWidth, setAttributes } ) {
+	function handleChange( newWidth ) {
+		// Check if we are toggling the width off
+		let width = selectedWidth === newWidth ? undefined : newWidth;
+		if ( newWidth === 'auto' ) {
+			width = undefined;
+		}
+		// Update attributes
+		setAttributes( { width } );
+	}
+
+	const options = [
+		{ value: 'auto', label: __( 'Auto' ) },
+		{ value: 25, label: '25%' },
+		{ value: 50, label: '50%' },
+		{ value: 75, label: '75%' },
+		{ value: 100, label: '100%' },
+	];
+
+	if ( ! selectedWidth ) {
+		selectedWidth = 'auto';
+	}
+
+	return (
+		<PanelBody title={ __( 'Width Settings' ) }>
+			<BottomSheetSelectControl
+				label={ __( 'Button width' ) }
+				value={ selectedWidth }
+				onChange={ handleChange }
+				options={ options }
+			/>
+		</PanelBody>
+	);
+}
+
+export default function Controls ( {
+	attributes,
+	setAttributes,
+	clientId,
+	borderRadiusValue,
+	getLinkSettings,
+	onShowLinkSettings,
+	onChangeBorderRadius,
+} ) {
+	const { url, width } = attributes;
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						title={ __( 'Edit link' ) }
+						icon={ link }
+						onClick={ onShowLinkSettings }
+						isActive={ url }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+			{ getLinkSettings( false ) }
+			<ColorEdit
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Border Settings' ) }>
+					<RangeControl
+						label={ __( 'Border Radius' ) }
+						minimumValue={ MIN_BORDER_RADIUS_VALUE }
+						maximumValue={ MAX_BORDER_RADIUS_VALUE }
+						value={ borderRadiusValue }
+						onChange={ onChangeBorderRadius }
+					/>
+				</PanelBody>
+				<WidthPanel
+					selectedWidth={ width }
+					setAttributes={ setAttributes }
+				/>
+				<PanelBody title={ __( 'Link Settings' ) }>
+					{ getLinkSettings( true ) }
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
+};

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -24,7 +24,7 @@ import {
 	RichText,
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
-	__experimentalUseSpacingProps as useSpacingProps,
+	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -24,6 +24,7 @@ import {
 	RichText,
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
+	__experimentalUseSpacingProps as useSpacingProps,
 	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
@@ -194,6 +195,7 @@ function ButtonEdit( props ) {
 
 	const borderRadius = style?.border?.radius;
 	const colorProps = useColorProps( attributes );
+	const spacingProps = useSpacingProps( attributes );
 	const ref = useRef();
 	const blockProps = useBlockProps( { ref } );
 
@@ -225,6 +227,7 @@ function ButtonEdit( props ) {
 							? borderRadius + 'px'
 							: undefined,
 						...colorProps.style,
+						...spacingProps.style,
 					} }
 					onSplit={ ( value ) =>
 						createBlock( 'core/button', {

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -9,25 +9,15 @@ import { withInstanceId, compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
-	InspectorControls,
-	BlockControls,
 	withGradient,
 	store as blockEditorStore,
 	getColorObjectByAttributeValues,
 	getGradientValueBySlug,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	RangeControl,
-	ToolbarGroup,
-	ToolbarButton,
-	LinkSettingsNavigation,
-	BottomSheetSelectControl,
-} from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { LinkSettingsNavigation } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { link } from '@wordpress/icons';
+import { useEffect, useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,10 +25,8 @@ import { link } from '@wordpress/icons';
 import richTextStyle from './rich-text.scss';
 import styles from './editor.scss';
 import ColorBackground from './color-background';
-import ColorEdit from './color-edit';
+import Controls from './controls';
 
-const MIN_BORDER_RADIUS_VALUE = 0;
-const MAX_BORDER_RADIUS_VALUE = 50;
 const INITIAL_MAX_WIDTH = 108;
 const MIN_WIDTH = 40;
 // Map of the percentage width to pixel subtraction that make the buttons fit nicely into columns.
@@ -49,145 +37,142 @@ const MIN_WIDTH_MARGINS = {
 	25: styles.button25?.marginLeft,
 };
 
-function WidthPanel( { selectedWidth, setAttributes } ) {
-	function handleChange( newWidth ) {
-		// Check if we are toggling the width off
-		let width = selectedWidth === newWidth ? undefined : newWidth;
-		if ( newWidth === 'auto' ) {
-			width = undefined;
-		}
-		// Update attributes
-		setAttributes( { width } );
-	}
+const usePrevious = ( value ) => {
+	const ref = useRef();
 
-	const options = [
-		{ value: 'auto', label: __( 'Auto' ) },
-		{ value: 25, label: '25%' },
-		{ value: 50, label: '50%' },
-		{ value: 75, label: '75%' },
-		{ value: 100, label: '100%' },
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] );
+
+	return ref.current;
+};
+
+const ButtonEdit = ( {
+	attributes,
+	colors,
+	gradients,
+	isSelected,
+	clientId,
+	onReplace,
+	mergeBlocks,
+	parentWidth,
+	setAttributes,
+	editorSidebarOpened,
+	numOfButtons,
+	onDeleteBlock,
+	closeSettingsBottomSheet,
+} ) => {
+	const {
+		placeholder,
+		text,
+		borderRadius,
+		align = 'center',
+		width,
+		gradient,
+	} = attributes;
+	const [ maxWidth, setMaxWidth ] = useState( INITIAL_MAX_WIDTH );
+	const [ isLinkSheetVisible, setIsLinkSheetVisible ] = useState( false );
+	const [ isButtonFocused, setIsButtonFocused ] = useState( true );
+	const [ placeholderTextWidth, setPlaceholderTextWidth ] = useState( 0 );
+	const richTextRef = useRef( null );
+
+	const prevParentWidth = usePrevious( parentWidth );
+	const wasSelected = usePrevious( isSelected );
+	const wasEditorSidebarOpened = usePrevious( editorSidebarOpened );
+	const wasLinkSheetVisible = usePrevious( isLinkSheetVisible );
+
+	const onClearSettings = () => {
+		setAttributes( {
+			url: '',
+			rel: '',
+			linkTarget: '',
+		} );
+
+		onHideLinkSettings();
+	};
+
+	const linkSettingsActions = [
+		{
+			label: __( 'Remove link' ),
+			onPress: onClearSettings,
+		},
 	];
 
-	if ( ! selectedWidth ) {
-		selectedWidth = 'auto';
-	}
+	const linkSettingsOptions = {
+		url: {
+			label: __( 'Button Link URL' ),
+			placeholder: __( 'Add URL' ),
+			autoFocus: true,
+			autoFill: true,
+		},
+		openInNewTab: {
+			label: __( 'Open in new tab' ),
+		},
+		linkRel: {
+			label: __( 'Link Rel' ),
+			placeholder: __( 'None' ),
+		},
+	};
 
-	return (
-		<PanelBody title={ __( 'Width Settings' ) }>
-			<BottomSheetSelectControl
-				label={ __( 'Button width' ) }
-				value={ selectedWidth }
-				onChange={ handleChange }
-				options={ options }
-			/>
-		</PanelBody>
-	);
-}
+	const noFocusLinkSettingOptions = {
+		...linkSettingsOptions,
+		url: {
+			...linkSettingsOptions.url,
+			autoFocus: false,
+		},
+	};
 
-class ButtonEdit extends Component {
-	constructor( props ) {
-		super( props );
-		this.onChangeText = this.onChangeText.bind( this );
-		this.onChangeBorderRadius = this.onChangeBorderRadius.bind( this );
-		this.onClearSettings = this.onClearSettings.bind( this );
-		this.onLayout = this.onLayout.bind( this );
-		this.onSetMaxWidth = this.onSetMaxWidth.bind( this );
-		this.dismissSheet = this.dismissSheet.bind( this );
-		this.onShowLinkSettings = this.onShowLinkSettings.bind( this );
-		this.onHideLinkSettings = this.onHideLinkSettings.bind( this );
-		this.onToggleButtonFocus = this.onToggleButtonFocus.bind( this );
-		this.onPlaceholderTextWidth = this.onPlaceholderTextWidth.bind( this );
-		this.setRef = this.setRef.bind( this );
-		this.onRemove = this.onRemove.bind( this );
-		this.getPlaceholderWidth = this.getPlaceholderWidth.bind( this );
+	useEffect( () => {
+		onSetMaxWidth();
+	}, [] );
 
-		this.state = {
-			maxWidth: INITIAL_MAX_WIDTH,
-			isLinkSheetVisible: false,
-			isButtonFocused: true,
-			placeholderTextWidth: 0,
-		};
-
-		this.linkSettingsActions = [
-			{
-				label: __( 'Remove link' ),
-				onPress: this.onClearSettings,
-			},
-		];
-
-		this.linkSettingsOptions = {
-			url: {
-				label: __( 'Button Link URL' ),
-				placeholder: __( 'Add URL' ),
-				autoFocus: true,
-				autoFill: true,
-			},
-			openInNewTab: {
-				label: __( 'Open in new tab' ),
-			},
-			linkRel: {
-				label: __( 'Link Rel' ),
-				placeholder: __( 'None' ),
-			},
-		};
-
-		this.noFocusLinkSettingOptions = {
-			...this.linkSettingsOptions,
-			url: {
-				...this.linkSettingsOptions.url,
-				autoFocus: false,
-			},
-		};
-	}
-
-	componentDidMount() {
-		this.onSetMaxWidth();
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		const { isSelected, editorSidebarOpened, parentWidth } = this.props;
-		const { isLinkSheetVisible, isButtonFocused } = this.state;
-
-		if ( isSelected && ! prevProps.isSelected ) {
-			this.onToggleButtonFocus( true );
+	useEffect( () => {
+		if ( isSelected && ! wasSelected ) {
+			onToggleButtonFocus( true );
 		}
 
-		if ( prevProps.parentWidth !== parentWidth ) {
-			this.onSetMaxWidth( null, true );
+		if ( prevParentWidth !== parentWidth ) {
+			onSetMaxWidth( null, true );
 		}
 
 		// Blur `RichText` on Android when link settings sheet or button settings sheet is opened,
 		// to avoid flashing caret after closing one of them
 		if (
-			( ! prevProps.editorSidebarOpened && editorSidebarOpened ) ||
-			( ! prevState.isLinkSheetVisible && isLinkSheetVisible )
+			( ! wasEditorSidebarOpened && editorSidebarOpened ) ||
+			( ! wasLinkSheetVisible && isLinkSheetVisible )
 		) {
-			if ( Platform.OS === 'android' && this.richTextRef ) {
-				this.richTextRef.blur();
-				this.onToggleButtonFocus( false );
+			if ( Platform.OS === 'android' && richTextRef.current ) {
+				richTextRef.current.blur();
+				onToggleButtonFocus( false );
 			}
 		}
 
-		if ( this.richTextRef ) {
+		if ( richTextRef.current ) {
 			if ( ! isSelected && isButtonFocused ) {
-				this.onToggleButtonFocus( false );
+				onToggleButtonFocus( false );
 			}
 
 			if ( isSelected && ! isButtonFocused ) {
 				AccessibilityInfo.isScreenReaderEnabled().then( ( enabled ) => {
 					if ( enabled ) {
-						this.onToggleButtonFocus( true );
-						this.richTextRef.focus();
+						onToggleButtonFocus( true );
+						richTextRef.current.focus();
 					}
 				} );
 			}
 		}
-	}
+	}, [
+		isSelected,
+		editorSidebarOpened,
+		parentWidth,
+		isLinkSheetVisible,
+		isButtonFocused,
+		wasSelected,
+		wasEditorSidebarOpened,
+		wasLinkSheetVisible,
+	] );
 
-	getBackgroundColor() {
-		const { attributes, colors, gradients } = this.props;
-		const { backgroundColor, gradient } = attributes;
-
+	const getBackgroundColor = () => {
 		// Return named gradient value if available.
 		const gradientValue = getGradientValueBySlug( gradients, gradient );
 
@@ -201,7 +186,7 @@ class ButtonEdit extends Component {
 		// do not load their color stylesheets in the editor.
 		const colorObject = getColorObjectByAttributeValues(
 			colors,
-			backgroundColor
+			attributes.backgroundColor
 		);
 
 		return (
@@ -210,10 +195,9 @@ class ButtonEdit extends Component {
 			colorProps.style?.background ||
 			styles.defaultButton.backgroundColor
 		);
-	}
+	};
 
-	getTextColor() {
-		const { attributes, colors } = this.props;
+	const getTextColor = () => {
 		const colorProps = getColorClassesAndStyles( attributes );
 
 		// Retrieve named color object to force inline styles for themes that
@@ -228,294 +212,216 @@ class ButtonEdit extends Component {
 			colorProps.style?.color ||
 			styles.defaultButton.color
 		);
-	}
+	};
 
-	onChangeText( value ) {
-		const { setAttributes } = this.props;
+	const onChangeText = ( value ) => {
 		setAttributes( { text: value } );
-	}
+	};
 
-	onChangeBorderRadius( value ) {
-		const { setAttributes } = this.props;
+	const onChangeBorderRadius = ( value ) => {
 		setAttributes( {
 			borderRadius: value,
 		} );
-	}
+	};
 
-	onShowLinkSettings() {
-		this.setState( { isLinkSheetVisible: true } );
-	}
+	const onShowLinkSettings = () => {
+		setIsLinkSheetVisible( true );
+	};
 
-	onHideLinkSettings() {
-		this.setState( { isLinkSheetVisible: false } );
-	}
+	const onHideLinkSettings = () => {
+		setIsLinkSheetVisible( false );
+	};
 
-	onToggleButtonFocus( value ) {
-		if ( value !== this.state.isButtonFocused ) {
-			this.setState( { isButtonFocused: value } );
+	const onToggleButtonFocus = ( value ) => {
+		if ( value !== isButtonFocused ) {
+			setIsButtonFocused( value );
 		}
-	}
+	};
 
-	onClearSettings() {
-		const { setAttributes } = this.props;
+	const onLayout = ( { nativeEvent } ) => {
+		const { layoutWidth } = nativeEvent.layout;
+		onSetMaxWidth( layoutWidth );
+	};
 
-		setAttributes( {
-			url: '',
-			rel: '',
-			linkTarget: '',
-		} );
-
-		this.onHideLinkSettings();
-	}
-
-	onLayout( { nativeEvent } ) {
-		const { width } = nativeEvent.layout;
-		this.onSetMaxWidth( width );
-	}
-
-	onSetMaxWidth( width, isParentWidthDidChange = false ) {
-		const { maxWidth } = this.state;
-		const { parentWidth } = this.props;
+	const onSetMaxWidth = ( newWidth, isParentWidthDidChange = false ) => {
 		const { marginRight: spacing } = styles.defaultButton;
 
 		const isParentWidthChanged = isParentWidthDidChange
 			? isParentWidthDidChange
 			: maxWidth !== parentWidth;
-		const isWidthChanged = maxWidth !== width;
+		const isWidthChanged = maxWidth !== newWidth;
 
-		if ( parentWidth && ! width && isParentWidthChanged ) {
-			this.setState( {
-				maxWidth: parentWidth - spacing,
-			} );
-		} else if ( ! parentWidth && width && isWidthChanged ) {
-			this.setState( { maxWidth: width - spacing } );
+		if ( parentWidth && ! newWidth && isParentWidthChanged ) {
+			setMaxWidth( parentWidth - spacing );
+		} else if ( ! parentWidth && newWidth && isWidthChanged ) {
+			setMaxWidth( newWidth - spacing );
 		}
-	}
+	};
 
-	onRemove() {
-		const { numOfButtons, onDeleteBlock, onReplace } = this.props;
-
+	const onRemove = () => {
 		if ( numOfButtons === 1 ) {
 			onDeleteBlock();
 		} else {
 			onReplace( [] );
 		}
-	}
+	};
 
-	dismissSheet() {
-		this.onHideLinkSettings();
-		this.props.closeSettingsBottomSheet();
-	}
+	const dismissSheet = () => {
+		onHideLinkSettings();
+		closeSettingsBottomSheet();
+	};
 
-	getLinkSettings( isCompatibleWithSettings ) {
-		const { isLinkSheetVisible } = this.state;
-		const { attributes, setAttributes } = this.props;
+	const getLinkSettings = ( isCompatibleWithSettings ) => {
 		return (
 			<LinkSettingsNavigation
 				isVisible={ isLinkSheetVisible }
 				url={ attributes.url }
 				rel={ attributes.rel }
 				linkTarget={ attributes.linkTarget }
-				onClose={ this.dismissSheet }
+				onClose={ dismissSheet }
 				setAttributes={ setAttributes }
 				withBottomSheet={ ! isCompatibleWithSettings }
 				hasPicker
-				actions={ this.linkSettingsActions }
+				actions={ linkSettingsActions }
 				options={
 					isCompatibleWithSettings
-						? this.linkSettingsOptions
-						: this.noFocusLinkSettingOptions
+						? linkSettingsOptions
+						: noFocusLinkSettingOptions
 				}
 				showIcon={ ! isCompatibleWithSettings }
 			/>
 		);
-	}
-
-	setRef( richText ) {
-		this.richTextRef = richText;
-	}
+	};
 
 	// Render `Text` with `placeholderText` styled as a placeholder
 	// to calculate its width which then is set as a `minWidth`
-	getPlaceholderWidth( placeholderText ) {
+	const getPlaceholderWidth = ( placeholderText ) => {
 		return (
 			<Text
 				style={ styles.placeholder }
-				onTextLayout={ this.onPlaceholderTextWidth }
+				onTextLayout={ onPlaceholderTextWidth }
 			>
 				{ placeholderText }
 			</Text>
 		);
-	}
+	};
 
-	onPlaceholderTextWidth( { nativeEvent } ) {
-		const { maxWidth, placeholderTextWidth } = this.state;
+	const onPlaceholderTextWidth = ( { nativeEvent } ) => {
 		const textWidth =
 			nativeEvent.lines[ 0 ] && nativeEvent.lines[ 0 ].width;
 
 		if ( textWidth && textWidth !== placeholderTextWidth ) {
-			this.setState( {
-				placeholderTextWidth: Math.min( textWidth, maxWidth ),
-			} );
+			setPlaceholderTextWidth( Math.min( textWidth, maxWidth ) );
 		}
+	};
+
+	const { paddingTop: spacing, borderWidth } = styles.defaultButton;
+
+	if ( parentWidth === 0 ) {
+		return null;
 	}
 
-	render() {
-		const {
-			attributes,
-			isSelected,
-			clientId,
-			onReplace,
-			mergeBlocks,
-			parentWidth,
-			setAttributes,
-		} = this.props;
-		const {
-			placeholder,
-			text,
-			borderRadius,
-			url,
-			align = 'center',
-			width,
-		} = attributes;
-		const { maxWidth, isButtonFocused, placeholderTextWidth } = this.state;
-		const { paddingTop: spacing, borderWidth } = styles.defaultButton;
+	const borderRadiusValue = Number.isInteger( borderRadius )
+		? borderRadius
+		: styles.defaultButton.borderRadius;
+	const outlineBorderRadius =
+		borderRadiusValue > 0 ? borderRadiusValue + spacing + borderWidth : 0;
 
-		if ( parentWidth === 0 ) {
-			return null;
-		}
-
-		const borderRadiusValue = Number.isInteger( borderRadius )
-			? borderRadius
-			: styles.defaultButton.borderRadius;
-		const outlineBorderRadius =
-			borderRadiusValue > 0
-				? borderRadiusValue + spacing + borderWidth
-				: 0;
-
-		// To achieve proper expanding and shrinking `RichText` on iOS, there is a need to set a `minWidth`
-		// value at least on 1 when `RichText` is focused or when is not focused, but `RichText` value is
-		// different than empty string.
-		let minWidth =
-			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? MIN_WIDTH
-				: placeholderTextWidth;
-		if ( width ) {
-			// Set the width of the button.
-			minWidth = Math.floor(
-				maxWidth * ( width / 100 ) - MIN_WIDTH_MARGINS[ width ]
-			);
-		}
-		// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
-		// a `placeholder` as an empty string when `RichText` is focused,
-		// because `AztecView` is calculating a `minWidth` based on placeholder text.
-		const placeholderText =
-			isButtonFocused || ( ! isButtonFocused && text && text !== '' )
-				? ''
-				: placeholder || __( 'Add text…' );
-
-		const backgroundColor = this.getBackgroundColor();
-		const textColor = this.getTextColor();
-		const isFixedWidth = !! width;
-
-		return (
-			<View onLayout={ this.onLayout }>
-				{ this.getPlaceholderWidth( placeholderText ) }
-				<ColorBackground
-					borderRadiusValue={ borderRadiusValue }
-					backgroundColor={ backgroundColor }
-					isSelected={ isSelected }
-				>
-					{ isSelected && (
-						<View
-							pointerEvents="none"
-							style={ [
-								styles.outline,
-								{
-									borderRadius: outlineBorderRadius,
-									borderColor: backgroundColor,
-								},
-							] }
-						/>
-					) }
-					<RichText
-						setRef={ this.setRef }
-						placeholder={ placeholderText }
-						value={ text }
-						onChange={ this.onChangeText }
-						style={ {
-							...richTextStyle.richText,
-							paddingLeft: isFixedWidth
-								? 0
-								: richTextStyle.richText.paddingLeft,
-							paddingRight: isFixedWidth
-								? 0
-								: richTextStyle.richText.paddingRight,
-							color: textColor,
-						} }
-						textAlign={ align }
-						placeholderTextColor={
-							styles.placeholderTextColor.color
-						}
-						identifier="text"
-						tagName="p"
-						minWidth={ minWidth } // The minimum Button size.
-						maxWidth={ isFixedWidth ? minWidth : maxWidth } // The width of the screen.
-						id={ clientId }
-						isSelected={ isButtonFocused }
-						withoutInteractiveFormatting
-						unstableOnFocus={ () =>
-							this.onToggleButtonFocus( true )
-						}
-						__unstableMobileNoFocusOnMount={ ! isSelected }
-						selectionColor={ textColor }
-						onBlur={ () => {
-							this.onSetMaxWidth();
-						} }
-						onReplace={ onReplace }
-						onRemove={ this.onRemove }
-						onMerge={ mergeBlocks }
-					/>
-				</ColorBackground>
-
-				{ isSelected && (
-					<>
-						<BlockControls>
-							<ToolbarGroup>
-								<ToolbarButton
-									title={ __( 'Edit link' ) }
-									icon={ link }
-									onClick={ this.onShowLinkSettings }
-									isActive={ url }
-								/>
-							</ToolbarGroup>
-						</BlockControls>
-						{ this.getLinkSettings( false ) }
-						<ColorEdit { ...this.props } />
-						<InspectorControls>
-							<PanelBody title={ __( 'Border Settings' ) }>
-								<RangeControl
-									label={ __( 'Border Radius' ) }
-									minimumValue={ MIN_BORDER_RADIUS_VALUE }
-									maximumValue={ MAX_BORDER_RADIUS_VALUE }
-									value={ borderRadiusValue }
-									onChange={ this.onChangeBorderRadius }
-								/>
-							</PanelBody>
-							<WidthPanel
-								selectedWidth={ width }
-								setAttributes={ setAttributes }
-							/>
-							<PanelBody title={ __( 'Link Settings' ) }>
-								{ this.getLinkSettings( true ) }
-							</PanelBody>
-						</InspectorControls>
-					</>
-				) }
-			</View>
+	// To achieve proper expanding and shrinking `RichText` on iOS, there is a need to set a `minWidth`
+	// value at least on 1 when `RichText` is focused or when is not focused, but `RichText` value is
+	// different than empty string.
+	let minWidth =
+		isButtonFocused || ( ! isButtonFocused && text && text !== '' )
+			? MIN_WIDTH
+			: placeholderTextWidth;
+	if ( width ) {
+		// Set the width of the button.
+		minWidth = Math.floor(
+			maxWidth * ( width / 100 ) - MIN_WIDTH_MARGINS[ width ]
 		);
 	}
-}
+	// To achieve proper expanding and shrinking `RichText` on Android, there is a need to set
+	// a `placeholder` as an empty string when `RichText` is focused,
+	// because `AztecView` is calculating a `minWidth` based on placeholder text.
+	const placeholderText =
+		isButtonFocused || ( ! isButtonFocused && text && text !== '' )
+			? ''
+			: placeholder || __( 'Add text…' );
+
+	const backgroundColor = getBackgroundColor();
+	const textColor = getTextColor();
+	const isFixedWidth = !! width;
+
+	return (
+		<View onLayout={ onLayout }>
+			{ getPlaceholderWidth( placeholderText ) }
+			<ColorBackground
+				borderRadiusValue={ borderRadiusValue }
+				backgroundColor={ backgroundColor }
+				isSelected={ isSelected }
+			>
+				{ isSelected && (
+					<View
+						pointerEvents="none"
+						style={ [
+							styles.outline,
+							{
+								borderRadius: outlineBorderRadius,
+								borderColor: backgroundColor,
+							},
+						] }
+					/>
+				) }
+				<RichText
+					ref={ richTextRef }
+					placeholder={ placeholderText }
+					value={ text }
+					onChange={ onChangeText }
+					style={ {
+						...richTextStyle.richText,
+						paddingLeft: isFixedWidth
+							? 0
+							: richTextStyle.richText.paddingLeft,
+						paddingRight: isFixedWidth
+							? 0
+							: richTextStyle.richText.paddingRight,
+						color: textColor,
+					} }
+					textAlign={ align }
+					placeholderTextColor={ styles.placeholderTextColor.color }
+					identifier="text"
+					tagName="p"
+					minWidth={ minWidth } // The minimum Button size.
+					maxWidth={ isFixedWidth ? minWidth : maxWidth } // The width of the screen.
+					id={ clientId }
+					isSelected={ isButtonFocused }
+					withoutInteractiveFormatting
+					unstableOnFocus={ () => onToggleButtonFocus( true ) }
+					__unstableMobileNoFocusOnMount={ ! isSelected }
+					selectionColor={ textColor }
+					onBlur={ () => {
+						onSetMaxWidth();
+					} }
+					onReplace={ onReplace }
+					onRemove={ onRemove }
+					onMerge={ mergeBlocks }
+				/>
+			</ColorBackground>
+
+			{ isSelected && (
+				<Controls
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					clientId={ clientId }
+					borderRadiusValue={ borderRadiusValue }
+					getLinkSettings={ getLinkSettings }
+					onShowLinkSettings={ onShowLinkSettings }
+					onChangeBorderRadius={ onChangeBorderRadius }
+				/>
+			) }
+		</View>
+	);
+};
 
 export default compose( [
 	withInstanceId,

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -10,6 +10,7 @@ import {
 	RichText,
 	useBlockProps,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
+	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
@@ -30,6 +31,7 @@ export default function save( { attributes, className } ) {
 
 	const borderRadius = style?.border?.radius;
 	const colorProps = getColorClassesAndStyles( attributes );
+	const spacingProps = getSpacingClassesAndStyles( attributes );
 	const buttonClasses = classnames(
 		'wp-block-button__link',
 		colorProps.className,
@@ -40,6 +42,7 @@ export default function save( { attributes, className } ) {
 	const buttonStyle = {
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 		...colorProps.style,
+		...spacingProps.style,
 	};
 
 	// The use of a `title` attribute here is soft-deprecated, but still applied


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
WIP to add native mobile support for padding to the Button block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
